### PR TITLE
Parse requests so they pull out custom Pipedrive IDs from the config

### DIFF
--- a/lib/pipekit/config.rb
+++ b/lib/pipekit/config.rb
@@ -4,21 +4,65 @@ module Pipekit
 
       attr_writer :file_path
 
-      def field(resource, key)
-        custom_fields
-          .fetch(resource, {})
+      # Finds the field name in the config from the Pipedrive ID
+      #
+      # Example
+      #
+      #   Config.field_name(:person, "asbasdfasc2343443")
+      #     # => "middle_name"
+      #
+      #   Config.field_name(:person, "name")
+      #     # => "name"
+      def field_name(resource, key)
+        custom_fields(resource)
+          .invert
           .fetch(key.to_s, key.to_s)
       end
 
-      def field_value(resource, key, value)
-        fetch("field_values", {})
-          .fetch(resource, {})
-          .fetch(key.to_s, {})
+      # Finds the Pipedrive field ID from the config
+      #
+      # Example
+      #
+      #   Config.field_id(:person, "middle_name")
+      #     # => "asbasdfasc2343443"
+      #
+      #   Config.field_id(:person, "name")
+      #     # => "name"
+      def field_id(resource, key)
+        custom_fields(resource)
+          .fetch(key.to_s, key.to_s)
+      end
+
+      # Finds the Pipedrive field value from the config
+      # translating from a Pipedrive ID in the config if one exists for that
+      # field/value
+      #
+      # Example
+      #
+      #   Config.field_value(:person, "inteview_quality", 66)
+      #     # => "Amazing"
+      #
+      #   Config.field_value(:person, "inteview_quality", "value_not_there")
+      #     # => "value_not_there"
+      def field_value(resource, field, value)
+        custom_field_values(resource, field)
           .fetch(value, value)
       end
 
-      def custom_fields
-        fetch("fields", {})
+      # Finds the Pipedrive field value ID from the config if one exists for that
+      # field/value
+      #
+      # Example
+      #
+      #   Config.field_value_id(:person, "inteview_quality", "Amazing")
+      #     # => 66
+      #
+      #   Config.field_value_id(:person, "inteview_quality", "value_not_there")
+      #     # => "value_not_there"
+      def field_value_id(resource, field, value)
+        custom_field_values(resource, field)
+          .invert
+          .fetch(value, value)
       end
 
       def fetch(key, default = nil)
@@ -43,6 +87,18 @@ module Pipekit
         yaml = ERB.new(File.read(file_path)).result
         YAML.load(yaml)
       end
+
+      def custom_fields(resource)
+        fetch("fields", {})
+          .fetch(resource.to_s, {})
+      end
+
+      def custom_field_values(resource, field)
+        fetch("field_values", {})
+          .fetch(resource.to_s, {})
+          .fetch(field.to_s, {})
+      end
+
     end
 
     NotSetError = Class.new(Exception)

--- a/lib/pipekit/field_repository.rb
+++ b/lib/pipekit/field_repository.rb
@@ -1,7 +1,7 @@
 module Pipekit
   module FieldRepository
       def get_by_key(key)
-        key = Config.field(parent_resource, key)
+        key = Config.field_name(parent_resource, key)
         search_fields("key", key)
       end
 

--- a/lib/pipekit/person.rb
+++ b/lib/pipekit/person.rb
@@ -11,7 +11,7 @@ module Pipekit
     end
 
     def create_or_update(fields)
-      person = get_by_email(fields[:email])
+      person = find_by(email: fields[:email])
       update(person["id"], fields)
     rescue ResourceNotFoundError
       create(fields)

--- a/lib/pipekit/request.rb
+++ b/lib/pipekit/request.rb
@@ -1,8 +1,5 @@
 require "httparty"
 
-# Add a parameter of @resource
-# then a result object can be returned in result from
-# this can then normalize the fields on the fly if they are configured
 module Pipekit
   class Request
     include HTTParty
@@ -36,7 +33,7 @@ module Pipekit
     # it couldn't find anything.
     def search_by_field(field:, value:)
       query = {field_type: "#{resource}Field",
-               field_key: Config.field(resource, field),
+               field_key: Config.field_name(resource, field),
                return_item_ids: true,
                term: value
       }
@@ -59,12 +56,12 @@ module Pipekit
       _get(id, query, get_request(id, query))
     end
 
-    def put(id, body)
-      response_from self.class.put(uri(id), options(body: body))
+    def put(id, data)
+      response_from self.class.put(uri(id), options(body: data))
     end
 
-    def post(body)
-      response_from self.class.post(uri, options(body: body))
+    def post(data)
+      response_from self.class.post(uri, options(body: data))
     end
 
     private
@@ -111,7 +108,7 @@ module Pipekit
     # meaning you don't have to worry about the custom IDs
     def parse_body(body)
       body.reduce({}) do |result, (field, value)|
-        field = Config.field(resource, field)
+        field = Config.field_name(resource, field)
         result.tap { |result| result[field] = value }
       end
     end

--- a/lib/pipekit/request.rb
+++ b/lib/pipekit/request.rb
@@ -109,6 +109,7 @@ module Pipekit
     def parse_body(body)
       body.reduce({}) do |result, (field, value)|
         field = Config.field_name(resource, field)
+        value = Config.field_value_id(resource, field, value)
         result.tap { |result| result[field] = value }
       end
     end

--- a/spec/pipekit/config_spec.rb
+++ b/spec/pipekit/config_spec.rb
@@ -2,6 +2,10 @@ module Pipekit
 
   RSpec.describe Config do
 
+    # This value is taken from the file at spec/support/config.yml
+    let(:middle_name_id) { "123abc" }
+    let(:interview_quality_id) { 66 }
+
     it "can access config values from the yaml file" do
       expect(described_class.fetch("test")).to eq(2)
     end
@@ -20,33 +24,55 @@ module Pipekit
     end
 
 
-    describe "fetching custom fields from the config" do
+    describe "fetching custom fields IDs from the config" do
       it "converts custom field names into their Pipedrive ID" do
-        result = described_class.field("person", "middle_name")
-        person_fields = described_class.custom_fields["person"]
-        expect(result).to eq(person_fields["middle_name"])
+        result = described_class.field_id("person", "middle_name")
+        expect(result).to eq(middle_name_id)
       end
 
       it "keeps keys that do not have a custom field the same" do
-        result = described_class.field("person", "last_name")
+        result = described_class.field_id("person", "last_name")
         expect(result).to eq("last_name")
       end
 
       it "keeps keys that do not have a resource with custom fields the same" do
-        result = described_class.field("blah", "last_name")
+        result = described_class.field_id("blah", "last_name")
+        expect(result).to eq("last_name")
+      end
+    end
+
+    describe "fetching field names from the config" do
+      it "converts custom Pipedrive IDs into their more readable name" do
+        result = described_class.field_name("person", middle_name_id)
+        expect(result).to eq("middle_name")
+      end
+
+      it "keeps keys that do not have a custom field the same" do
+        result = described_class.field_name("person", "last_name")
         expect(result).to eq("last_name")
       end
     end
 
     describe "fetching custom field values from the config" do
       it "converts custom field values from their Pipedrive ID into their meaningful name" do
-        custom_values = described_class.fetch("field_values")["person"]["interview_quality"]
-        result = described_class.field_value("person", :interview_quality, custom_values.keys.first)
-        expect(result).to eq(custom_values.values.first)
+        result = described_class.field_value("person", :interview_quality, interview_quality_id)
+        expect(result).to eq("Amazing")
       end
 
       it "keeps values that do not have a custom field the same" do
         result = described_class.field_value("person", "interview_quality", "value_not_there")
+        expect(result).to eq("value_not_there")
+      end
+    end
+
+    describe "fetching custom field value IDs from the config" do
+      it "converts custom field values into their Pipedrive ID when it exists in the config" do
+        result = described_class.field_value_id("person", :interview_quality, "Amazing")
+        expect(result).to eq(interview_quality_id)
+      end
+
+      it "keeps values that do not have a custom field value ID the same" do
+        result = described_class.field_value_id("person", "interview_quality", "value_not_there")
         expect(result).to eq("value_not_there")
       end
     end

--- a/spec/pipekit/person_spec.rb
+++ b/spec/pipekit/person_spec.rb
@@ -23,13 +23,12 @@ module Pipekit
 
       it "updates a person on Pipedrive when they already exist" do
         id = 123
-
-        allow(request).to receive(:get).and_return({"id" => id})
-
         fields = {
           email: "test@example.com",
           name: "Testy McTest"
         }
+
+        allow(request).to receive(:get).with("find", term: fields[:email], search_by_email: 1).and_return([{"id" => id}])
 
         repository.create_or_update(fields)
         expect(request).to have_received(:put).with(id, fields)

--- a/spec/pipekit/request_spec.rb
+++ b/spec/pipekit/request_spec.rb
@@ -37,7 +37,7 @@ module Pipekit
 
     describe "#search_by_field" do
       it "makes a get request to Pipedrive /searchResults with a field key and value" do
-        field_key = Config.field("person", "middle_name")
+        field_key = Config.field_name("person", "middle_name")
         field_type = "personField"
         term = "princess"
         url = "searchResults/field?api_token=&field_key=#{field_key}&field_type=#{field_type}&return_item_ids=true&term=#{term}"
@@ -55,7 +55,7 @@ module Pipekit
     describe "#put" do
       it "makes a put request to Pipedrive with the correct options" do
         fields = {"middle_name" => "Dave"}
-        custom_field = Config.field("person", "middle_name")
+        custom_field = Config.field_name("person", "middle_name")
         id = "123"
 
         stub = stub_put("persons/123", "#{custom_field}=Dave")
@@ -69,7 +69,7 @@ module Pipekit
     describe "#post" do
       it "makes a post request to Pipedrive with the correct options" do
         fields = {"name" => "Bob", "middle_name" => "Milhous"}
-        custom_field = Config.field("person", "middle_name")
+        custom_field = Config.field_name("person", "middle_name")
 
         stub = stub_post("persons", "name=Bob&#{custom_field}=Milhous")
 
@@ -82,7 +82,7 @@ module Pipekit
     describe "#post" do
       it "makes a post request to Pipedrive with the correct options" do
         fields = {"name" => "Bob", "middle_name" => "Milhous"}
-        custom_field = Config.field("person", "middle_name")
+        custom_field = Config.field_name("person", "middle_name")
 
         stub = stub_post("persons", "name=Bob&#{custom_field}=Milhous")
 

--- a/spec/pipekit/request_spec.rb
+++ b/spec/pipekit/request_spec.rb
@@ -54,11 +54,12 @@ module Pipekit
 
     describe "#put" do
       it "makes a put request to Pipedrive with the correct options" do
-        fields = {"middle_name" => "Dave"}
+        fields = {"middle_name" => "Dave", "interview_quality" => "Amazing"}
         custom_field = Config.field_name("person", "middle_name")
+        interview_quality_id = Config.field_value_id("person", "interview_quality", "Amazing")
         id = "123"
 
-        stub = stub_put("persons/123", "#{custom_field}=Dave")
+        stub = stub_put("persons/123", "#{custom_field}=Dave&interview_quality=#{interview_quality_id}")
 
         request.put(id, fields)
 

--- a/spec/support/field_repository_shared.rb
+++ b/spec/support/field_repository_shared.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples "a field repository" do |parent_resource|
     describe "finding by key" do
 
       it "finds field details by key when it exists" do
-        allow(config).to receive(:field).with(parent_resource, "age").and_return("fieldkey")
+        allow(config).to receive(:field_name).with(parent_resource, "age").and_return("fieldkey")
 
         response = [{"key" => "no"},{"key" => "fieldkey"}]
         allow(request).to receive(:get).and_return(response)


### PR DESCRIPTION
Once again this is needed so that we don't have to worry about changing say an Interview Result from Amazing to the weird 66 that Pipedrive requires as the ID for the value. 

This handles that, cleans up the config class, and adds a to_hash class that is also required in the near future

Closes #9 

We realised that we didn't need to create a resource object in the end, so following Rule #4 of simple design (fewest elements) we did the parsing in the Request.rb object for the moment. There's another object there, but it doesn't need to be extracted just yet