### PR TITLE
Find by email exactly

### DIFF
--- a/lib/pipekit/deal.rb
+++ b/lib/pipekit/deal.rb
@@ -10,7 +10,7 @@ module Pipekit
     # Finds a person by their email, then finds the first deal related to that
     # person and updates it with the params provided
     def update_by_person(email, params, person_repo: Person.new)
-      person = person_repo.find_by(email: email)
+      person = person_repo.find_exactly_by_email(email)
       deal = get_by_person_id(person[:id], person_repo: person_repo).first
       update(deal[:id], params)
     end

--- a/lib/pipekit/person.rb
+++ b/lib/pipekit/person.rb
@@ -10,6 +10,12 @@ module Pipekit
       request.get("find", term: name)
     end
 
+    def find_exactly_by_email(email)
+      get_by_email(email).select do |item|
+        item["email"] == email
+      end.first
+    end
+
     def update_by_email(email, fields)
       person = find_by(email: email)
       update(person["id"], fields)

--- a/lib/pipekit/person.rb
+++ b/lib/pipekit/person.rb
@@ -17,7 +17,7 @@ module Pipekit
     end
 
     def update_by_email(email, fields)
-      person = find_by(email: email)
+      person = find_exactly_by_email(email)
       update(person["id"], fields)
     end
 

--- a/lib/pipekit/repository.rb
+++ b/lib/pipekit/repository.rb
@@ -39,6 +39,7 @@ module Pipekit
     #
     # Returns a Hash or nil if none found.
     def find_by(options)
+      warn "Using `Repository#find_by` with an email may return inexact matches" if email_key?(options)
       where(options, true).first
     end
 
@@ -94,6 +95,10 @@ module Pipekit
 
     def resource
       self.class.to_s.split("::").last.tap { |name| name[0] = name[0].downcase }
+    end
+
+    def email_key?(options)
+      options.keys.first && options.keys.first.to_s == "email"
     end
   end
 end

--- a/lib/pipekit/version.rb
+++ b/lib/pipekit/version.rb
@@ -1,3 +1,3 @@
 module Pipekit
-  VERSION = "1.2.0"
+  VERSION = "2.0.0"
 end

--- a/spec/pipekit/deal_spec.rb
+++ b/spec/pipekit/deal_spec.rb
@@ -29,7 +29,7 @@ module Pipekit
       person_id = 123
       deal_id = 456
 
-      allow(person).to receive(:find_by).with(email: email).and_return(id: person_id)
+      allow(person).to receive(:find_exactly_by_email).with(email).and_return(id: person_id)
       allow(person).to receive(:find_deals).with(person_id).and_return([{id: deal_id}])
 
       repository = described_class.new(request)

--- a/spec/pipekit/person_spec.rb
+++ b/spec/pipekit/person_spec.rb
@@ -44,6 +44,15 @@ module Pipekit
         expect(request).to have_received(:get).with("find", term: email, search_by_email: 1)
       end
 
+      it "finds by email exactly" do
+        email = "test@example.com"
+        id = 123
+        stub_find_by_email(email, id)
+
+        result = repository.find_exactly_by_email(email)
+        expect(result["id"]).to eq 123
+      end
+
       it "gets by name" do
         name = "Dave Smith"
 

--- a/spec/pipekit/person_spec.rb
+++ b/spec/pipekit/person_spec.rb
@@ -62,6 +62,24 @@ module Pipekit
       end
     end
 
+    describe "warning on dangerous email finds" do
+      it "warns on using find_by with an email" do
+        email = "test@example.com"
+        id = 123
+        stub_find_by_email(email, id)
+
+        expect { repository.find_by(email: email) }.to output(
+          "Using `Repository#find_by` with an email may return inexact matches\n").to_stderr
+      end
+
+      it "does not warn on using find_by with a name" do
+        name = "Geoff"
+        stub_find_by_name(name)
+
+        expect { repository.find_by(name: name) }.not_to output.to_stderr
+      end
+    end
+
     it "updates by a person's email" do
       email = "test@blah.com"
       id = 123
@@ -84,6 +102,13 @@ module Pipekit
         .and_return([
           {"id" => id + 5, "email" => "nottheemailyouarelookingfor@email.com"},
           {"id" => id, "email" => email}
+        ])
+    end
+
+    def stub_find_by_name(name)
+      allow(request).to receive(:get).with("find", term: name)
+        .and_return([
+          {"id" => 0, "name" => name}
         ])
     end
   end

--- a/spec/pipekit/person_spec.rb
+++ b/spec/pipekit/person_spec.rb
@@ -80,8 +80,11 @@ module Pipekit
     end
 
     def stub_find_by_email(email, id)
-      allow(request).to receive(:get).with("find", term: email, search_by_email: 1).and_return([{"id" => id}])
-
+      allow(request).to receive(:get).with("find", term: email, search_by_email: 1)
+        .and_return([
+          {"id" => id + 5, "email" => "nottheemailyouarelookingfor@email.com"},
+          {"id" => id, "email" => email}
+        ])
     end
   end
 end


### PR DESCRIPTION
Pipedrive now returns partial matches on emails, which means using `Person#find_by` was finding other records that happened to share a substring.

Notable changes:

1. Add `Person#find_exactly_by_email` which does another pass over Pipedrive's results, only returning emails that match exactly. It also uses the `search_by_email` flag, which this method did not use before (but it didn't make any obvious difference?).
2. Update `Person#update_by_email` to use the above, presuming that only exact matches are desired.
3. Update `Deal#update_by_person` to use the above, presuming that only exactly matches are desired.

This is essentially the smallest amount of work I could do that would fix the problem. I know little about this gem, how widely it is used or what its backwards compatibility contract is. As such I'm being conservative. I hope a reviewer will guide this PR down the right path.