### PR TITLE
fix(result): Handle null additional_data in pagination_data

### DIFF
--- a/lib/pipekit/result.rb
+++ b/lib/pipekit/result.rb
@@ -43,9 +43,7 @@ module Pipekit
     attr_reader :response_data, :resource
 
     def pagination_data
-      response_data
-        .fetch("additional_data", {})
-        .fetch("pagination", {})
+      response_data.dig("additional_data", "pagination") || {}
     end
 
     def response_body

--- a/spec/pipekit/result_spec.rb
+++ b/spec/pipekit/result_spec.rb
@@ -1,0 +1,26 @@
+module Pipekit
+  RSpec.describe Result do
+    subject(:repository) { described_class.new(request) }
+    let(:request) { instance_spy("Pipedrive::Request") }
+
+    describe "pagination_data" do
+
+      let(:response_data) do
+        { "data" => [1, 2, 3], "success" => true,
+          "additional_data" => { "pagination" => { "more_items_in_collection" => true, "next_start" => 3 } } }
+      end
+      let(:resource) { {} }
+
+      it "returns the pagination data" do
+        instance =  described_class.new(resource, response_data)
+        expect(instance.send(:pagination_data)).to eq({ "more_items_in_collection" => true, "next_start" => 3 })
+      end
+
+      it "returns {} if there additional_data is nil" do
+        response_data = { "data" => [1, 2, 3], "success" => true, "additional_data" => nil }
+        instance = described_class.new(resource, response_data)
+        expect(instance.send(:pagination_data)).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Fix pagination_data method to handle null additional_data**

This patch addresses an issue in the `pagination_data` method within `result.rb` where an error occurred when `additional_data` was null. The fix modifies the method to safely navigate through potentially null values using Ruby's dig method, ensuring robustness and preventing errors in such scenarios.

## Changes Made:

Updated `pagination_data` method in `result.rb` to safely access  `additional_data` using `dig`.
Added test cases in `result_spec.rb` to validate behavior for both present and **null** `additional_data`.

## Test Coverage:

Introduced new tests to cover scenarios where `additional_data` is both present and **null**.
Ensured that `pagination_data` correctly returns expected results or an empty hash when `additional_data` is null.
This change enhances the reliability of the `pagination_data` method, ensuring consistent behavior across various input conditions.

